### PR TITLE
Fix mouse selection.

### DIFF
--- a/source/ts/control/cursors.ts
+++ b/source/ts/control/cursors.ts
@@ -20,9 +20,11 @@ export class Cursors extends utils.PosterClass {
     private _selecting_text: boolean;
     private _clipboard: clipboard.Clipboard;
     private _history: history.IHistory;
+    private _el: HTMLElement;
     
-    public constructor(model: document_model.DocumentModel, clipboard: clipboard.Clipboard, history: history.IHistory) {
+    public constructor(el: HTMLElement, model: document_model.DocumentModel, clipboard: clipboard.Clipboard, history: history.IHistory) {
         super();
+        this._el = el;
         this._model = model;
         this.get_row_char = undefined;
         this.cursors = [];
@@ -145,8 +147,9 @@ export class Cursors extends utils.PosterClass {
      * @param  e - mouse event containing the coordinates.
      */
     public set_selection(e: MouseEvent): void {
-        var x: number = e.offsetX;
-        var y: number = e.offsetY;
+        var touchpane: ClientRect = this._el.getBoundingClientRect();
+        var x: number = e.clientX - touchpane.left;
+        var y: number = e.clientY - touchpane.top;
         if (this._selecting_text && this.get_row_char) {
             var location: row_renderer.ICharacterCoords = this.get_row_char(x, y);
             this.cursors[this.cursors.length-1].set_primary(location.row_index, location.char_index);

--- a/source/ts/control/normalizer.ts
+++ b/source/ts/control/normalizer.ts
@@ -18,16 +18,20 @@ export class Normalizer extends utils.PosterClass {
     /**
      * Listen to the events of an element.
      */
-    public listen_to(el: HTMLElement): void {
+    public listen_to(el: HTMLElement, mouse: boolean = true, keyboard: boolean = true): void {
         var hooks = [];
-        hooks.push(utils.hook(el, 'onkeypress', this._proxy('press', this._handle_keypress_event, el)));
-        hooks.push(utils.hook(el, 'onkeydown',  this._proxy('down', this._handle_keyboard_event, el)));
-        hooks.push(utils.hook(el, 'onkeyup',  this._proxy('up', this._handle_keyboard_event, el)));
-        hooks.push(utils.hook(el, 'ondblclick',  this._proxy('dblclick', this._handle_mouse_event, el)));
-        hooks.push(utils.hook(el, 'onclick',  this._proxy('click', this._handle_mouse_event, el)));
-        hooks.push(utils.hook(el, 'onmousedown',  this._proxy('down', this._handle_mouse_event, el)));
-        hooks.push(utils.hook(el, 'onmouseup',  this._proxy('up', this._handle_mouse_event, el)));
-        hooks.push(utils.hook(el, 'onmousemove',  this._proxy('move', this._handle_mousemove_event, el)));
+        if (keyboard) {
+            hooks.push(utils.hook(el, 'onkeypress', this._proxy('press', this._handle_keypress_event, el)));
+            hooks.push(utils.hook(el, 'onkeydown',  this._proxy('down', this._handle_keyboard_event, el)));
+            hooks.push(utils.hook(el, 'onkeyup',  this._proxy('up', this._handle_keyboard_event, el)));
+            hooks.push(utils.hook(el, 'ondblclick',  this._proxy('dblclick', this._handle_mouse_event, el)));
+            hooks.push(utils.hook(el, 'onclick',  this._proxy('click', this._handle_mouse_event, el)));
+        }
+        if (mouse) { 
+            hooks.push(utils.hook(el, 'onmousedown',  this._proxy('down', this._handle_mouse_event, el)));
+            hooks.push(utils.hook(el, 'onmouseup',  this._proxy('up', this._handle_mouse_event, el)));
+            hooks.push(utils.hook(el, 'onmousemove',  this._proxy('move', this._handle_mousemove_event, el)));
+        }
         this._el_hooks[utils.hash(el)] = hooks;
     }
 

--- a/source/ts/document_controller.ts
+++ b/source/ts/document_controller.ts
@@ -24,10 +24,10 @@ export class DocumentController extends utils.PosterClass {
         this.clipboard = new clipboard.Clipboard(el);
         this.normalizer = new normalizer.Normalizer();
         this.normalizer.listen_to(el);
-        this.normalizer.listen_to(this.clipboard.hidden_input);
+        this.normalizer.listen_to(this.clipboard.hidden_input, false, true);
         this.map = new keymap.Map(this.normalizer);
         this.map.map(default_keymap.map);
         this.history = new history.History(this.map)
-        this.cursors = new cursors.Cursors(model, this.clipboard, this.history);
+        this.cursors = new cursors.Cursors(el, model, this.clipboard, this.history);
     }
 }


### PR DESCRIPTION
Fixes a bug in the mouse text selection where the events would occasionally fire on the hidden clipboard element and produce the wrong offset, causing the highlighted text to jump.

Bug introduced by #89